### PR TITLE
Rename execution arn input param in DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ class ExampleSimulation extends Simulation {
   val scn = scenario("SFN DSL test")
     .exec(
       sfn("Start Hello World Execution").startExecution
-        .executionArn(sfnArn)
+        .arn(sfnArn)
         .payload("{}")
     )
     .pause(5000.milliseconds)

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     gatling("io.gatling:gatling-commons:${gatlingVersion}")
     gatling("software.amazon.awssdk:sfn:${awsSdkVersion}")
     gatling("software.amazon.awssdk:apache-client:${apacheClientVersion}")
-    gatling("dev.joss:gatling-stepfunction-extension:1.1.0")
+    gatling(fileTree(dir: '../build/libs', include: ['*.jar']))
 }
 
 spotless {

--- a/example/commands.txt
+++ b/example/commands.txt
@@ -18,4 +18,4 @@ awslocal stepfunctions start-execution \
 --state-machine-arn "arn:aws:states:eu-west-1:000000000000:stateMachine:hello-world-sfn" \
 --input "{\"IsHelloWorldExample\": true}"
 
-awslocal stepfunctions get-execution-history --execution-arn "arn:aws:states:eu-west-1:000000000000:execution:hello-world-sfn:2a9e0704-3c60-4405-a17d-ea68cdb4c506"
+awslocal stepfunctions get-execution-history --execution-arn "arn:aws:states:eu-west-1:000000000000:execution:hello-world-sfn:6cedcd2b-d6cc-4c8c-9df9-102e6bfb87aa"

--- a/example/src/performance/scala/simulation/ExampleSimulation.scala
+++ b/example/src/performance/scala/simulation/ExampleSimulation.scala
@@ -1,14 +1,12 @@
 package simulation
 
 import dev.joss.gatling.sfn.Predef._
-import dev.joss.gatling.sfn.protocol.SfnProtocol
+import dev.joss.gatling.sfn.protocol.{SfnProtocol, SfnProtocolBuilder}
 import io.gatling.core.Predef._
 import io.gatling.core.scenario.Simulation
+import io.gatling.core.structure.{PopulationBuilder, ScenarioBuilder}
 import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.auth.credentials.{
-  AwsSessionCredentials,
-  StaticCredentialsProvider
-}
+import software.amazon.awssdk.auth.credentials.{AwsSessionCredentials, StaticCredentialsProvider}
 import software.amazon.awssdk.http.apache.ApacheHttpClient
 import software.amazon.awssdk.services.sfn.SfnClient
 
@@ -16,8 +14,6 @@ import java.net.URI
 import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
 class ExampleSimulation extends Simulation {
-  var sfnProtocol = sfn.client(sfnClient)
-
   var sfnClient: SfnClient = SfnClient
     .builder()
     .endpointOverride(URI.create("http://localhost:4566"))
@@ -29,20 +25,23 @@ class ExampleSimulation extends Simulation {
     )
     .httpClient(ApacheHttpClient.create())
     .build()
+
+  var sfnProtocol: SfnProtocolBuilder = sfn.client(sfnClient)
+
   var sfnArn =
     "arn:aws:states:eu-west-1:000000000000:stateMachine:hello-world-sfn"
 
-  val scn = scenario("SFN DSL test")
+  val scn: ScenarioBuilder = scenario("SFN DSL test")
     .exec(
       sfn("Start Hello World Exection").startExecution
-        .executionArn(sfnArn)
+        .arn(sfnArn)
         .payload("{\"IsHelloWorldExample\": true}")
     )
     .pause(5000.milliseconds)
     .exec(sfn("Check the response").checkSucceeded)
 
-  val requests = scn.inject {
-    constantUsersPerSec(100) during (5 minutes)
+  val requests: PopulationBuilder = scn.inject {
+    constantUsersPerSec(1) during (5 seconds)
   }
   setUp(requests).protocols(sfnProtocol)
 

--- a/src/main/scala/dev/joss/gatling/sfn/SfnDsl.scala
+++ b/src/main/scala/dev/joss/gatling/sfn/SfnDsl.scala
@@ -31,7 +31,7 @@ trait SfnDsl {
   def sfn(requestName: Expression[String]): SfnDslBuilderBase =
     new SfnDslBuilderBase(requestName)
 
-  /** Convert a JmsProtocolBuilder to a JmsProtocol <p> Simplifies the API
+  /** Convert a SfnProtocolBuilder to a SfnProtocol <p> Simplifies the API
     * somewhat (you can pass the builder reference to the scenario
     * .protocolConfig() method)
     */

--- a/src/main/scala/dev/joss/gatling/sfn/request/SfnDslBuilderBase.scala
+++ b/src/main/scala/dev/joss/gatling/sfn/request/SfnDslBuilderBase.scala
@@ -8,17 +8,17 @@ import io.gatling.core.action.builder.ActionBuilder
 import io.gatling.core.session.Expression
 
 final class SfnDslBuilderBase(requestName: Expression[String]) {
-  def startExecution: StartExecutionDslBuilder.ExecutionArn =
-    new StartExecutionDslBuilder.ExecutionArn(requestName)
+  def startExecution: StartExecutionDslBuilder.Arn =
+    new StartExecutionDslBuilder.Arn(requestName)
 
   def checkSucceeded: CheckSucceededDslBuilder =
     CheckSucceededDslBuilder(requestName)
 }
 
 object StartExecutionDslBuilder {
-  final class ExecutionArn(requestName: Expression[String]) {
-    def executionArn(executionArn: Expression[String]): Payload =
-      new Payload(requestName, executionArn)
+  final class Arn(requestName: Expression[String]) {
+    def arn(arn: Expression[String]): Payload =
+      new Payload(requestName, arn)
   }
 
   final class Payload(

--- a/src/test/scala/dev/joss/gatling/sfn/SfnCompileTest.scala
+++ b/src/test/scala/dev/joss/gatling/sfn/SfnCompileTest.scala
@@ -1,9 +1,10 @@
 package dev.joss.gatling.sfn
 
 import dev.joss.gatling.sfn.Predef._
-import dev.joss.gatling.sfn.protocol.SfnProtocol
+import dev.joss.gatling.sfn.protocol.{SfnProtocol, SfnProtocolBuilder}
 import io.gatling.core.Predef._
 import io.gatling.core.scenario.Simulation
+import io.gatling.core.structure.{PopulationBuilder, ScenarioBuilder}
 import software.amazon.awssdk.services.sfn.SfnClient
 
 import scala.concurrent.duration.DurationInt
@@ -16,18 +17,18 @@ class SfnCompileTest extends Simulation {
   var sfnArn =
     "some-test-arn"
 
-  var sfnProtocol = sfn.client(sfnClient)
+  var sfnProtocol: SfnProtocolBuilder = sfn.client(sfnClient)
 
-  val scn = scenario("SFN DSL test")
+  val scn: ScenarioBuilder = scenario("SFN DSL test")
     .exec(
       sfn("Start an Execution").startExecution
-        .executionArn(sfnArn)
+        .arn(sfnArn)
         .payload("{}")
     )
     .pause(5000.milliseconds)
     .exec(sfn("Check the response is success").checkSucceeded)
 
-  val requests = scn.inject {
+  val requests: PopulationBuilder = scn.inject {
     constantUsersPerSec(100) during (5 minutes)
   }
   setUp(requests).protocols(sfnProtocol)


### PR DESCRIPTION
Updated API definition to be `arn` instead of `executionArn` in the DSL. As per #2 the following is now valid:
```scala
val scn = scenario("SFN DSL test")
    .exec(
      sfn("Start Hello World Execution").startExecution
        .arn(sfnArn)
        .payload("{}")
    )
    .pause(5000.milliseconds)
    .exec(sfn("Check the response").checkSucceeded)
```