### PR TITLE
:sparkles: Adding ability to check a give state has succeeded

### DIFF
--- a/example/src/performance/scala/simulation/ExampleSimulation.scala
+++ b/example/src/performance/scala/simulation/ExampleSimulation.scala
@@ -12,6 +12,7 @@ import software.amazon.awssdk.auth.credentials.{
 }
 import software.amazon.awssdk.http.apache.ApacheHttpClient
 import software.amazon.awssdk.services.sfn.SfnClient
+import software.amazon.awssdk.services.sfn.model.HistoryEventType.WAIT_STATE_EXITED
 
 import java.net.URI
 import scala.concurrent.duration.DurationInt
@@ -36,12 +37,16 @@ class ExampleSimulation extends Simulation {
 
   val scn: ScenarioBuilder = scenario("SFN DSL test")
     .exec(
-      sfn("Start Hello World Exection").startExecution
+      sfn("Start Hello World Execution").startExecution
         .arn(sfnArn)
         .payload("{\"IsHelloWorldExample\": true}")
     )
-    .pause(5000.milliseconds)
-    .exec(sfn("Check the response").checkSucceeded)
+    .pause(7000.milliseconds)
+    .exec(
+      sfn("Check the response").checkStateSucceeded
+        .stateName("Wait2")
+        .stateType(WAIT_STATE_EXITED)
+    )
 
   val requests: PopulationBuilder = scn.inject {
     constantUsersPerSec(1) during (5 seconds)

--- a/src/main/scala/dev/joss/gatling/sfn/SfnDsl.scala
+++ b/src/main/scala/dev/joss/gatling/sfn/SfnDsl.scala
@@ -6,6 +6,7 @@ import dev.joss.gatling.sfn.protocol.{
   SfnProtocolBuilderBase
 }
 import dev.joss.gatling.sfn.request.{
+  CheckStateSucceededDslBuilder,
   CheckSucceededDslBuilder,
   SfnDslBuilderBase,
   StartExecutionDslBuilder
@@ -45,6 +46,10 @@ trait SfnDsl {
 
   implicit def sfnDslBuilder2ActionBuilder(
       builder: CheckSucceededDslBuilder
+  ): ActionBuilder = builder.build
+
+  implicit def sfnDslBuilder2ActionBuilder(
+      builder: CheckStateSucceededDslBuilder
   ): ActionBuilder = builder.build
 
 }

--- a/src/main/scala/dev/joss/gatling/sfn/action/CheckStateSucceededAction.scala
+++ b/src/main/scala/dev/joss/gatling/sfn/action/CheckStateSucceededAction.scala
@@ -1,0 +1,104 @@
+package dev.joss.gatling.sfn.action
+
+import dev.joss.gatling.sfn.request.attributes.SfnCheckStateAttributes
+import io.gatling.commons.util.Clock
+import io.gatling.core.CoreComponents
+import io.gatling.core.action.Action
+import io.gatling.core.session._
+import io.gatling.core.stats.StatsEngine
+import software.amazon.awssdk.services.sfn.SfnClient
+import software.amazon.awssdk.services.sfn.model.{
+  GetExecutionHistoryRequest,
+  GetExecutionHistoryResponse,
+  HistoryEvent,
+  HistoryEventType
+}
+
+import java.time.Instant
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+import scala.util.Try
+case class CheckStateSucceededAction(
+    sfnClient: SfnClient,
+    coreComponents: CoreComponents,
+    next: Action,
+    id: String,
+    attributes: SfnCheckStateAttributes
+) extends SfnActionBase {
+  override def statsEngine: StatsEngine = coreComponents.statsEngine
+  override def clock: Clock = coreComponents.clock
+  override def name: String = "Step Function Task Execution Completion"
+
+  override def execute(session: Session): Unit = {
+
+    val executionArn: String = session("executionArn").as[String]
+    val stateName: String = attributes.stateName(session).toOption.get
+    val stateType: HistoryEventType = attributes.stateType(session).toOption.get
+
+    val executionHistoryRequest = GetExecutionHistoryRequest.builder
+    executionHistoryRequest.executionArn(executionArn)
+
+    val tryExecutionHistoryResponse: Try[GetExecutionHistoryResponse] =
+      trySfnRequest(() =>
+        sfnClient.getExecutionHistory(executionHistoryRequest.build())
+      )
+
+    if (tryExecutionHistoryResponse.isFailure) {
+      val failedMessage: String =
+        tryExecutionHistoryResponse.failed.get.getMessage
+      logFailure(
+        name,
+        session,
+        Instant.now().toEpochMilli,
+        Instant.now().toEpochMilli,
+        s"Could not get the execution history for the execution with arn: $executionArn. Reason: $failedMessage"
+      )
+    } else {
+      val executionHistoryEvents: Seq[HistoryEvent] =
+        tryExecutionHistoryResponse.get.events.asScala.toList
+      val tryGetStateExitedEvent: Try[HistoryEvent] =
+        getTaskExecutionCompleteState(
+          stateName,
+          stateType,
+          executionHistoryEvents
+        )
+
+      val startTime: Long = executionHistoryEvents.head.timestamp.toEpochMilli
+
+      if (tryGetStateExitedEvent.isFailure) {
+        val failedMessage: String = tryGetStateExitedEvent.failed.get.getMessage
+        logFailure(
+          name,
+          session,
+          startTime,
+          Instant.now().toEpochMilli,
+          s"The task $stateName has not finished or a previous task failed. Reason: $failedMessage"
+        )
+      } else {
+        val taskExitedEvent: HistoryEvent = tryGetStateExitedEvent.get
+        val endTime: Long = taskExitedEvent.timestamp.toEpochMilli
+        logSuccess(
+          name,
+          session,
+          startTime,
+          endTime
+        )
+      }
+    }
+  }
+
+  private def getTaskExecutionCompleteState(
+      task: String,
+      stateType: HistoryEventType,
+      sfnExecutionEvents: Seq[HistoryEvent]
+  ): Try[HistoryEvent] = {
+    Try(
+      sfnExecutionEvents
+        .filter(event =>
+          event.`type`.equals(
+            stateType
+          ) && event.stateExitedEventDetails.name.equals(task)
+        )
+        .head
+    )
+  }
+}

--- a/src/main/scala/dev/joss/gatling/sfn/action/CheckStateSucceededActionBuilder.scala
+++ b/src/main/scala/dev/joss/gatling/sfn/action/CheckStateSucceededActionBuilder.scala
@@ -1,16 +1,23 @@
 package dev.joss.gatling.sfn.action
 
+import dev.joss.gatling.sfn.request.attributes.SfnCheckStateAttributes
 import io.gatling.core.action.Action
 import io.gatling.core.structure.ScenarioContext
 import io.gatling.core.util.NameGen
 
-case class CheckSucceededActionBuilder()
+case class CheckStateSucceededActionBuilder(attributes: SfnCheckStateAttributes)
     extends SfnActionBuilderBase
     with NameGen {
   override def build(ctx: ScenarioContext, next: Action): Action = {
     val protocol = getProtocol(ctx)
     val client = protocol.sfnClient
-    CheckSucceededAction(client, ctx.coreComponents, next, genName(""))
+    CheckStateSucceededAction(
+      client,
+      ctx.coreComponents,
+      next,
+      genName(""),
+      attributes
+    )
   }
 
 }

--- a/src/main/scala/dev/joss/gatling/sfn/action/SfnActionBase.scala
+++ b/src/main/scala/dev/joss/gatling/sfn/action/SfnActionBase.scala
@@ -1,0 +1,56 @@
+package dev.joss.gatling.sfn.action
+
+import dev.joss.gatling.sfn.protocol.SfnProtocol
+import io.gatling.commons.stats.{KO, OK}
+import io.gatling.core.action.ExitableAction
+import io.gatling.core.action.builder.ActionBuilder
+import io.gatling.core.session.Session
+import io.gatling.core.structure.ScenarioContext
+
+import java.util.concurrent.Callable
+import scala.util.Try
+
+trait SfnActionBase extends ExitableAction {
+  protected def logSuccess(
+      requestName: String,
+      session: Session,
+      start: Long,
+      end: Long
+  ): Unit = {
+    statsEngine.logResponse(
+      session.scenario,
+      session.groups,
+      requestName,
+      start,
+      end,
+      OK,
+      None,
+      None
+    )
+    next ! session.markAsSucceeded
+  }
+
+  protected def logFailure(
+      requestName: String,
+      session: Session,
+      start: Long,
+      end: Long,
+      message: String
+  ): Unit = {
+    statsEngine.logResponse(
+      session.scenario,
+      session.groups,
+      requestName,
+      start,
+      end,
+      KO,
+      None,
+      Some(message)
+    )
+    next ! session.markAsFailed
+  }
+
+  protected def trySfnRequest[T](request: Callable[T]): Try[T] = {
+    Try(request.call())
+  }
+}

--- a/src/main/scala/dev/joss/gatling/sfn/action/SfnActionBuilderBase.scala
+++ b/src/main/scala/dev/joss/gatling/sfn/action/SfnActionBuilderBase.scala
@@ -4,7 +4,7 @@ import dev.joss.gatling.sfn.protocol.SfnProtocol
 import io.gatling.core.action.builder.ActionBuilder
 import io.gatling.core.structure.ScenarioContext
 
-abstract class SfnActionBuilder extends ActionBuilder {
+abstract class SfnActionBuilderBase extends ActionBuilder {
   protected def getProtocol(ctx: ScenarioContext): SfnProtocol = {
     ctx.protocolComponentsRegistry
       .components(SfnProtocol.sfnProtocolKey)

--- a/src/main/scala/dev/joss/gatling/sfn/action/StartExecutionActionBuilder.scala
+++ b/src/main/scala/dev/joss/gatling/sfn/action/StartExecutionActionBuilder.scala
@@ -1,12 +1,12 @@
 package dev.joss.gatling.sfn.action
 
-import dev.joss.gatling.sfn.request.SfnAttributes
+import dev.joss.gatling.sfn.request.attributes.SfnExecuteAttributes
 import io.gatling.core.action.Action
 import io.gatling.core.structure.ScenarioContext
 import io.gatling.core.util.NameGen
 
-case class StartExecutionActionBuilder(attributes: SfnAttributes)
-    extends SfnActionBuilder
+case class StartExecutionActionBuilder(attributes: SfnExecuteAttributes)
+    extends SfnActionBuilderBase
     with NameGen {
   override def build(ctx: ScenarioContext, next: Action): Action = {
     val protocol = getProtocol(ctx)

--- a/src/main/scala/dev/joss/gatling/sfn/request/attributes/SfnCheckStateAttributes.scala
+++ b/src/main/scala/dev/joss/gatling/sfn/request/attributes/SfnCheckStateAttributes.scala
@@ -1,0 +1,10 @@
+package dev.joss.gatling.sfn.request.attributes
+
+import io.gatling.core.session.Expression
+import software.amazon.awssdk.services.sfn.model.HistoryEventType
+
+case class SfnCheckStateAttributes(
+    requestName: Expression[String],
+    stateName: Expression[String],
+    stateType: Expression[HistoryEventType]
+)

--- a/src/main/scala/dev/joss/gatling/sfn/request/attributes/SfnExecuteAttributes.scala
+++ b/src/main/scala/dev/joss/gatling/sfn/request/attributes/SfnExecuteAttributes.scala
@@ -1,7 +1,7 @@
-package dev.joss.gatling.sfn.request
+package dev.joss.gatling.sfn.request.attributes
 
 import io.gatling.core.session.Expression
-case class SfnAttributes(
+case class SfnExecuteAttributes(
     requestName: Expression[String],
     stateMachineArn: Expression[String],
     input: Expression[String]

--- a/src/test/scala/dev/joss/gatling/sfn/SfnCompileTest.scala
+++ b/src/test/scala/dev/joss/gatling/sfn/SfnCompileTest.scala
@@ -6,6 +6,7 @@ import io.gatling.core.Predef._
 import io.gatling.core.scenario.Simulation
 import io.gatling.core.structure.{PopulationBuilder, ScenarioBuilder}
 import software.amazon.awssdk.services.sfn.SfnClient
+import software.amazon.awssdk.services.sfn.model.HistoryEventType.TASK_STATE_EXITED
 
 import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
@@ -32,5 +33,25 @@ class SfnCompileTest extends Simulation {
     constantUsersPerSec(100) during (5 minutes)
   }
   setUp(requests).protocols(sfnProtocol)
+
+  val scn2: ScenarioBuilder = scenario("SFN DSL test")
+    .exec(
+      sfn("Start an Execution").startExecution
+        .arn(sfnArn)
+        .payload("{}")
+    )
+    .pause(5000.milliseconds)
+    .exec(
+      sfn(
+        "Check the response from a specific state is success"
+      ).checkStateSucceeded
+        .stateName("sdsdsd")
+        .stateType(TASK_STATE_EXITED)
+    )
+
+  val requests2: PopulationBuilder = scn2.inject {
+    constantUsersPerSec(100) during (5 minutes)
+  }
+  setUp(requests2).protocols(sfnProtocol)
 
 }


### PR DESCRIPTION
We can now specify a specific state has succeeded using the following: 

```scala
sfn( "Check the response from a specific state is success")
  .checkStateSucceeded
  .stateName("sdsdsd")
  .stateType(TASK_STATE_EXITED)
```

Where `stateName` is the name of the state and `stateType` is the associated type. See the [AWS docs on States](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-states.html) for more information